### PR TITLE
Sorting features

### DIFF
--- a/app.css
+++ b/app.css
@@ -10,7 +10,7 @@ form {
   display: none;
 }
 
-input.stop.btn, .spinner {
+input.stop.btn, .icon-loading-spinner {
   display: none;
 }
 

--- a/app.js
+++ b/app.js
@@ -34,23 +34,23 @@
 
     beforeSort: function(event) {
       this.$('.icon-loading-spinner').css('display', 'inline-block');
-      var $tr = this.$(event.target);
-      $tr.addClass('sorted');
-      $tr.siblings().removeClass('sorted ascending');
-      $tr.toggleClass('ascending');
+      var $th = this.$(event.target);
+      $th.addClass('sorted');
+      $th.siblings().removeClass('sorted ascending');
+      $th.toggleClass('ascending');
     },
 
     // Toggles acending/decending order of the column header clicked
     sortTable: function(event) {
-      var $tr = this.$(event.target);
-      var position = $tr.index();
-      var $tableBody = $tr.closest('table').find('tbody');
+      var $th = this.$(event.target);
+      var position = $th.index();
+      var $tableBody = $th.closest('table').find('tbody');
 
       var newList = _.sortBy( $tableBody.find('tr'), function(el) {
         return this.$(el).find('td:eq(' + position + ')').text().toLowerCase();
       }.bind(this) );
 
-      if ( $tr.hasClass('ascending') ) {
+      if ( $th.hasClass('ascending') ) {
         $tableBody.empty().append(newList);
       } else {
         $tableBody.empty().append( newList.reverse() );

--- a/app.js
+++ b/app.js
@@ -9,7 +9,8 @@
       'click .search.btn':                  'startSearch',
       'requestMacros.done':                 'filterResults',
       'click .stop.btn':                    'stopSearch',
-      'click .results th':                  'sortTable'
+      'mousedown .results th':              'beforeSort',
+      'mouseup .results th':                'sortTable'
     },
 
     requests: {
@@ -31,15 +32,19 @@
       this.$('.query.date').datepicker({ dateFormat: "yy-mm-dd" });
     }),
 
+    beforeSort: function(event) {
+      this.$('.icon-loading-spinner').css('display', 'inline-block');
+      var $tr = this.$(event.target);
+      $tr.addClass('sorted');
+      $tr.siblings().removeClass('sorted ascending');
+      $tr.toggleClass('ascending');
+    },
+
     // Toggles acending/decending order of the column header clicked
     sortTable: function(event) {
       var $tr = this.$(event.target);
       var position = $tr.index();
       var $tableBody = $tr.closest('table').find('tbody');
-
-      $tr.addClass('sorted');
-      $tr.siblings().removeClass('sorted ascending');
-      $tr.toggleClass('ascending');
 
       var newList = $tableBody.find('tr').sort( function(a,b) {
         var itemA = this.$(a).find('td:eq(' + position + ')').text().toLowerCase();
@@ -52,6 +57,7 @@
       }.bind(this) );
 
       $tableBody.empty().append(newList);
+      this.$('.icon-loading-spinner').hide();
     },
 
     startSearch: function() {

--- a/app.js
+++ b/app.js
@@ -46,17 +46,16 @@
       var position = $tr.index();
       var $tableBody = $tr.closest('table').find('tbody');
 
-      var newList = $tableBody.find('tr').sort( function(a,b) {
-        var itemA = this.$(a).find('td:eq(' + position + ')').text().toLowerCase();
-        var itemB = this.$(b).find('td:eq(' + position + ')').text().toLowerCase();
-        if ( $tr.hasClass('ascending') ) {
-          return (itemA > itemB) ? 1 : (itemA < itemB) ? -1 : 0;
-        } else {
-          return (itemA > itemB) ? -1 : (itemA < itemB) ? 1 : 0;
-        }
+      var newList = _.sortBy( $tableBody.find('tr'), function(el) {
+        return this.$(el).find('td:eq(' + position + ')').text().toLowerCase();
       }.bind(this) );
 
-      $tableBody.empty().append(newList);
+      if ( $tr.hasClass('ascending') ) {
+        $tableBody.empty().append(newList);
+      } else {
+        $tableBody.empty().append( newList.reverse() );
+      }
+
       this.$('.icon-loading-spinner').hide();
     },
 

--- a/app.js
+++ b/app.js
@@ -70,7 +70,7 @@
         this.$('.results tbody').empty();
         this.$('.results th').removeClass('sorted ascending');
         this.stopped = false;
-        this.$('.spinner').show();
+        this.$('.icon-loading-spinner').css('display', 'inline-block');
         this.$('.stop.btn').show();
         this.$('.count').text('');
         this.$('.results ul').empty();
@@ -92,7 +92,7 @@
       this.$('.search.btn').prop('value', 'Search');
       this.$('.stop.btn').hide();
       this.stopped = true;
-      this.$('.spinner').hide();
+      this.$('.icon-loading-spinner').hide();
     },
 
     filterResults: function(data) {
@@ -200,7 +200,7 @@
       this.$('.results tbody').append(resultsTemplate);
 
       // Display result count
-      this.$('.count').html("<h3>Displaying " + this.$('.results tbody tr').length + " results</h3>");
+      this.$('.count').html("Displaying " + this.$('.results tbody tr').length + " results");
 
     },
 

--- a/app.js
+++ b/app.js
@@ -36,27 +36,19 @@
       var $tr = this.$(event.target);
       var position = $tr.index();
       var $tableBody = $tr.closest('table').find('tbody');
-      var greaterThan,
-          lessThan;
 
       $tr.addClass('sorted');
       $tr.siblings().removeClass('sorted ascending');
       $tr.toggleClass('ascending');
 
-      if ( $tr.hasClass('ascending') ) {
-        greaterThan = 1;
-        lessThan = -1;
-      } else {
-        greaterThan = -1;
-        lessThan = 1;
-      }
-
       var newList = $tableBody.find('tr').sort( function(a,b) {
-        var itemA = this.$(a).find('td:eq(' + position + ')').text();
-        var itemB = this.$(b).find('td:eq(' + position + ')').text();
-        if ( itemA > itemB ) return greaterThan;
-        if ( itemA < itemB ) return lessThan;
-        return 0;
+        var itemA = this.$(a).find('td:eq(' + position + ')').text().toLowerCase();
+        var itemB = this.$(b).find('td:eq(' + position + ')').text().toLowerCase();
+        if ( $tr.hasClass('ascending') ) {
+          return (itemA > itemB) ? 1 : (itemA < itemB) ? -1 : 0;
+        } else {
+          return (itemA > itemB) ? -1 : (itemA < itemB) ? 1 : 0;
+        }
       }.bind(this) );
 
       $tableBody.empty().append(newList);

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,6 @@
   "defaultLocale": "en",
   "private": true,
   "location": "nav_bar",
-  "version": "1.0",
+  "version": "0.0.2",
   "frameworkVersion": "1.0"
 }

--- a/templates/search.hdbs
+++ b/templates/search.hdbs
@@ -34,11 +34,12 @@
   <label class='checkbox pull-right'>
     <input type='checkbox' class="check status" /> Inlcude inactive macros
   </label>
-  <span class='spinner'>{{spinner "dotted"}}</span>
 </form>
 
 <div class="results">
- <span class='count'></span>
+ <h4 class="list-heading">
+  <span class='count'></span><i class="icon-loading-spinner"></i>
+</h4>
  <table class='table table-striped'>
   <thead>
     <tr>
@@ -52,3 +53,5 @@
   </tbody>
  </table>
 </div>
+
+


### PR DESCRIPTION
- style changes
  - I'm basically trying to mimic ZD's view interface when displaying the results of the search
  - display spinner while sorting
  - display up/down carets (next to column heading) before sort is complete (they were only showing after search was complete)
  - It seems the only way to do this is to fire two separate events (one for mousedown: the css, and one for mouseup: the actual sorting), otherwise the css doesn't redraw (because the browser is waiting for the function to complete)
  - use spinner icon instead of helper: the helper doesn't respond to `.css('display', 'inline-block')` for some reason
- use underscore.js to sort results; so much faster and cleaner than using plain js
