### PR TITLE
Title search

### DIFF
--- a/app.css
+++ b/app.css
@@ -2,6 +2,14 @@ form {
   width: 550px;
 }
 
+select.rules {
+  margin-bottom: 10px;
+}
+
+table.search-options {
+  margin-bottom: 10px;
+}
+
 .table td {
   border: 0;
 }

--- a/app.js
+++ b/app.js
@@ -149,6 +149,13 @@
     },
 
     filterBy: {
+      title: function(items) {
+        var query = this._getStringQuery('title');
+        return _.filter(items, function(item) {
+          return item.title.indexOf(query) > -1;
+        });
+      },
+
       tag: function(items) {
         var query = this._getStringQuery('tag');
         var results = _.filter(items, function(item) {

--- a/app.js
+++ b/app.js
@@ -160,7 +160,7 @@
         var query = this._getStringQuery('tag');
         var results = _.filter(items, function(item) {
           // Filter out tags which don't match query
-          var tags = _.filter(this._getValues(item), function(tag) {
+          var tags = _.filter(this._getTagValues(item), function(tag) {
             return tag.indexOf(query) > -1;
           });
           if ( tags.length > 0 ) return item;
@@ -221,8 +221,12 @@
         return results;
       },
 
-      _getValues: function(macro) {
-        var values = _.pluck(macro.actions, 'value');
+      _getTagValues: function(item) {
+        var tagActions = _.filter(item.actions, function(action) {
+          return action.field.indexOf('_tags') > -1 ||
+                 action.field.indexOf('custom_fields_') > -1;
+        });
+        var values = _.pluck(tagActions, 'value');
         // Remove null values
         return _.reject(values, function(value) { return !value; });
       },

--- a/app.js
+++ b/app.js
@@ -152,7 +152,7 @@
       title: function(items) {
         var query = this._getStringQuery('title');
         return _.filter(items, function(item) {
-          return item.title.indexOf(query) > -1;
+          return item.title.match(query);
         });
       },
 
@@ -161,7 +161,7 @@
         var results = _.filter(items, function(item) {
           // Filter out tags which don't match query
           var tags = _.filter(this._getTagValues(item), function(tag) {
-            return tag.indexOf(query) > -1;
+            return tag.match(query);
           });
           if ( tags.length > 0 ) return item;
         }.bind(this) );
@@ -174,7 +174,7 @@
         var results = _.filter(items, function(item) {
           // Filter out comments which don't match query
           var comments = _.filter(this._getComments(item), function(comment) {
-            return comment.indexOf(query) > -1;
+            return comment.match(query);
           });
           if ( comments.length > 0 ) return item;
         }.bind(this) );
@@ -187,7 +187,7 @@
         var results = _.filter(triggers, function(trigger) {
           // Filter out notifications which don't match query
           var notifications = _.filter(this._getNotifications(trigger), function(notification) {
-            return notification.indexOf(query) > -1;
+            return notification.match(query);
           });
           if ( notifications.length > 0 ) return trigger;
         }.bind(this) );
@@ -252,7 +252,7 @@
       },
 
       _getStringQuery: function(type) {
-        return this.$('.query.' + type).val().toLowerCase();
+        return new RegExp(this.$('.query.' + type).val(), 'i');
       }.bind(this),
 
       _getStartDateQuery: function(type) {

--- a/templates/automations-search.hdbs
+++ b/templates/automations-search.hdbs
@@ -1,6 +1,12 @@
 <table class='table search-options'>
   <tbody>
     <tr>
+      <td><input type='checkbox' class='filter title' data-filter='title' /></td>
+      <td>Title includes</td>
+      <td><input type='text' class='query title' /></td>
+      <td></td>
+    </tr>
+    <tr>
       <td><input type='checkbox' class='filter tag' data-filter='tag' /></td>
       <td>Tags include</td>
       <td><input type='text' class='query tag' /></td>

--- a/templates/macros-search.hdbs
+++ b/templates/macros-search.hdbs
@@ -1,6 +1,12 @@
 <table class='table search-options'>
   <tbody>
     <tr>
+      <td><input type='checkbox' class='filter title' data-filter='title' /></td>
+      <td>Title includes</td>
+      <td><input type='text' class='query title' /></td>
+      <td></td>
+    </tr>
+    <tr>
       <td><input type='checkbox' class='filter tag' data-filter='tag' /></td>
       <td>Tags include</td>
       <td><input type='text' class='query tag' /></td>

--- a/templates/triggers-search.hdbs
+++ b/templates/triggers-search.hdbs
@@ -1,6 +1,12 @@
 <table class='table search-options'>
   <tbody>
     <tr>
+      <td><input type='checkbox' class='filter title' data-filter='title' /></td>
+      <td>Title includes</td>
+      <td><input type='text' class='query title' /></td>
+      <td></td>
+    </tr>
+    <tr>
       <td><input type='checkbox' class='filter tag' data-filter='tag' /></td>
       <td>Tags include</td>
       <td><input type='text' class='query tag' /></td>


### PR DESCRIPTION
@PolRod if you have a sec. All good if you don't!

I had to change the string from the query box to a regexp since (for some reason that I still don't understand) it wasn't matching when you put a macro title with double-colons in it (e.g., the query "foo::bar" wouldn't match "foo::bartholomew" in the macro title).

Converting to regexps was causing an issue with the data returned from the `getValues` function because it was also returning comments, which have arrays (instead of strings) as their values. So, although `indexOf` "worked" on comments (since it is a string and array method), it would only match exact strings. But switching to regexp made it break :(

To fix this, I made the `getValues` function only return values that were for tags fields or for custom fields. I don't think there are any custom fields that would return an array as the value, but I could be wrong.
