### PR TITLE
replace special characters in queries with escape squences

### DIFF
--- a/app.js
+++ b/app.js
@@ -282,7 +282,9 @@
       },
 
       getStringQuery: function(type) {
-        return new RegExp(this.$('.query.' + type).val(), 'i');
+        var query = this.$('.query.' + type).val();
+        var escapedQuery = query.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+        return new RegExp(escapedQuery, 'i');
       }.bind(this),
 
       getStartDateQuery: function(type) {


### PR DESCRIPTION
@PolRod 

because I was having trouble searching using a query that included brackets. For example, I couldn't  search for "Some macro title [ES]" using "[ES]". It wasn't working because I was turning the query into a regex but not escaping the special characters.
