### PR TITLE
change macro edit link to use new macro interface

### DIFF
--- a/app.js
+++ b/app.js
@@ -196,7 +196,8 @@
       var options = {
         results:    results,
         type:       searchType,
-        isDcSearch: searchType == 'dynamicContent'
+        isDcSearch: searchType == 'dynamicContent',
+        isMacroSearch: searchType == 'macro'
       };
       var resultsTemplate = this.renderTemplate('results', options);
       this.$('.results tbody').append(resultsTemplate);

--- a/templates/results.hdbs
+++ b/templates/results.hdbs
@@ -14,15 +14,19 @@
             edit
           </a>
         {{else}}
-          <a href="/rules/new?copy_id={{this.id}}&filter={{../../type}}" target="_blank">
-            clone
-          </a>
-          <span class="delim">|</span>
           {{#if ../../../isMacroSearch}}
+            <a href="admin/macros/new?macro_id={{this.id}}">
+              clone
+            </a>
+            <span class="delim">|</span>
             <a href="admin/macros/{{this.id}}" class='edit-this'>
               edit
             </a>
           {{else}}
+            <a href="/rules/new?copy_id={{this.id}}&filter={{../../type}}" target="_blank">
+              clone
+            </a>
+            <span class="delim">|</span>
             <a href="/rules/{{this.id}}/edit" target="_blank" class='edit-this'>
               edit
             </a>

--- a/templates/results.hdbs
+++ b/templates/results.hdbs
@@ -18,9 +18,15 @@
             clone
           </a>
           <span class="delim">|</span>
-          <a href="/rules/{{this.id}}/edit" target="_blank" class='edit-this'>
-            edit
-          </a>
+          {{#if ../../../isMacroSearch}}
+            <a href="admin/macros/{{this.id}}" class='edit-this'>
+              edit
+            </a>
+          {{else}}
+            <a href="/rules/{{this.id}}/edit" target="_blank" class='edit-this'>
+              edit
+            </a>
+          {{/if}}
         {{/if}}
       </td>
       <td>{{this.created_at}}</td>


### PR DESCRIPTION
https://lumoslabs.atlassian.net/browse/CS-272

This changed the "edit" link in the macro search results to utilize the new Zendesk macro interface. Since the automations and triggers still use the old interface, I left them as is, and instead added a flag in the data sent to the template and a conditional within the template itself.
