### PR TITLE
Allow search on rich text macros

### DIFF
--- a/app.js
+++ b/app.js
@@ -404,7 +404,11 @@
           return action.value && (["comment_value", "comment_value_html"].includes(action.field));
         });
         var comments = _.map(actions, function(action) {
-          return action.value[1].toLowerCase();
+          if (typeof(action.value) == "string") {
+            return action.value.toLowerCase();
+          } else {
+            return action.value[1].toLowerCase();
+          }
         });
         return comments;
       },

--- a/app.js
+++ b/app.js
@@ -401,7 +401,7 @@
 
       getComments: function(macro) {
         var actions = _.filter(macro.actions, function(action) {
-          return action.value && action.field == "comment_value";
+          return action.value && (["comment_value", "comment_value_html"].includes(action.field));
         });
         var comments = _.map(actions, function(action) {
           return action.value[1].toLowerCase();

--- a/app.js
+++ b/app.js
@@ -404,12 +404,13 @@
           return action.value && (["comment_value", "comment_value_html"].includes(action.field));
         });
         var comments = _.map(actions, function(action) {
+          //Rich content macros' value is a string instead of an array. A string full of html.
           if (typeof(action.value) == "string") {
-            return action.value.toLowerCase();
+            return this.stripHTMLTags(action.value.toLowerCase());
           } else {
             return action.value[1].toLowerCase();
           }
-        });
+        }.bind(this));
         return comments;
       },
 
@@ -446,6 +447,10 @@
 
       getEndDateQuery: function(queryType) {
         return new Date( this.$('.query.' + queryType + '.end-date').val().toLowerCase() );
+      }.bind(this),
+
+      stripHTMLTags: function(string) {
+        return string.replace(/<br>/, " ").replace(/<(?:.|\n)*?>/gm, '');
       }.bind(this)
     }
   };


### PR DESCRIPTION
The API response for rich text macros is different from those with plain text. This allows the app to search for rich text macros as well.