### PR TITLE
Remove the clone link from macro results

### DIFF
--- a/templates/results.hdbs
+++ b/templates/results.hdbs
@@ -27,13 +27,9 @@
           </a>
         {{/if}}
         {{#if ../../searchFormType.article}}
-          <!-- don't renter clone or edit links for article results-->
+          <!-- don't render clone or edit links for article results-->
         {{/if}}
         {{#if ../../searchFormType.macro}}
-          <a href="admin/macros/new?macro_id={{this.id}}">
-            clone
-          </a>
-          <span class="delim">|</span>
           <a href="admin/macros/{{this.id}}" class='edit-this'>
             edit
           </a>


### PR DESCRIPTION
Removing Clone link because it doesn’t work and I think is unneeded,  and messes up links if I try to copy it into a spreadsheet.