### PR TITLE
check in manifest file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /tmp
 node_modules/
-dist/
+dist/*
+!dist/manifest.json

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Best Search",
+  "author": {
+    "name": "Joe Palmieri",
+    "email": "jpalmieri@lumoslabs.com",
+    "url": ""
+  },
+  "defaultLocale": "en",
+  "private": true,
+  "location": {
+    "support": {
+      "nav_bar": "assets/index.html"
+    }
+  },
+  "version": "0.1.4",
+  "frameworkVersion": "2.0",
+  "migrator": {
+    "migratedAt": "Tue Sep 25 2018",
+    "version": "0.3.3"
+  }
+}


### PR DESCRIPTION
I earlier ignored the entire /dist directory. Since this is where the built files live, we don't need to pay attention to the history of these files (we can just track the changes of the source files).

But the strange arrangement of this app scaffold sources a file in this directory (source [here](https://github.com/jpalmieri/zendesk_best_search/blob/f8aaaab7b866b281ac45ffe39e4075d2f50008ac/lib/javascripts/i18n.js#L2); aliased [here](https://github.com/jpalmieri/zendesk_best_search/blob/f8aaaab7b866b281ac45ffe39e4075d2f50008ac/webpack.config.js#L74-L76)). With this setup, this file must be checked in. Otherwise, anyone cloning the file and trying to build will run into a 'missing file' error.